### PR TITLE
Set manage_guest to align with latest release of vagrant-hostmanager …

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.34.0
+version: 3.34.1
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure("2") do |config|
 
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
+  config.hostmanager.manage_guest = true
   config.hostmanager.ignore_private_ip = false
   config.hostmanager.include_offline = true
 

--- a/provisioners/windows/provision.ps1
+++ b/provisioners/windows/provision.ps1
@@ -254,7 +254,7 @@ if (-not($config.websites.iis)) {
         new-webbinding -name ("$($args[0]).{0}" -f $instance.domain) -hostheader ("$($args[0]).{0}" -f $instance.domain) -port 443 -protocol https
         $certificate = New-SelfSignedCertificate -DnsName "localhost.localdomain" -CertStoreLocation cert:\LocalMachine\My
         $certificate | new-item 0.0.0.0!443
-   }
+    }
 
     echo "`n`n==> Starting websites"
     if (get-childitem -Path IIS:\Sites) {


### PR DESCRIPTION
…v1.8.0 (on by default, but semantics).