### PR TITLE
Vagrant: There is a bug in Vagrant::Plugin::Manager that assumes the …

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.67.3
+version: 3.67.4
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/catapult/catapult.rb
+++ b/catapult/catapult.rb
@@ -79,7 +79,7 @@ module Catapult
         next if plugin_hash.has_key?(p)
         result = true
         logger.warn("Installing plugin #{p}")
-        pm.install_plugin(p)
+        pm.install_plugin(p, sources: ["https://rubygems.org"])
       end
       if result
         catapult_exception('Required Vagrant plugins were installed, please re-run your Vagrant command for the plugins to take effect.')


### PR DESCRIPTION
…source is local when plugins.json is empty.