### PR TITLE
Vagrant: An EOF was happening when getting a full list of repositorie…

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.67.5
+version: 3.67.6
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/catapult/catapult.rb
+++ b/catapult/catapult.rb
@@ -509,7 +509,7 @@ module Catapult
     if @configuration["company"]["bitbucket_username"] == nil || @configuration["company"]["bitbucket_password"] == nil
       catapult_exception("Please set [\"company\"][\"bitbucket_username\"] and [\"company\"][\"bitbucket_password\"] in secrets/configuration.yml")
     else
-      uri = URI("https://api.bitbucket.org/1.0/user/repositories")
+      uri = URI("https://api.bitbucket.org/1.0/user")
       Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
         request = Net::HTTP::Get.new uri.request_uri
         request.basic_auth "#{@configuration["company"]["bitbucket_username"]}", "#{@configuration["company"]["bitbucket_password"]}"


### PR DESCRIPTION
…s, tracked down to a potential keep-alive at the Atlasssian load balancer level. Use a shorter responded  API call for testing authentication.