### PR TITLE
RedHat: Explicitly require python and python-setuptools for very bare…

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.80.0
+version: 3.80.1
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/provisioners/redhat/provision_server.sh
+++ b/provisioners/redhat/provision_server.sh
@@ -52,6 +52,8 @@ ${output_swap_utilization} \
 }
 
 # install shyaml
+yum install python -y
+yum install python-setuptools -y
 sudo easy_install pip
 sudo pip install --upgrade pip
 sudo pip install shyaml --upgrade


### PR DESCRIPTION
… boxes.