### PR TITLE
Fixes #555 Platform: Monkey patch for vagrant-aws - find and write th…

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.91.1
+version: 3.91.2
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/catapult/catapult.rb
+++ b/catapult/catapult.rb
@@ -994,6 +994,10 @@ module Catapult
             # id
             if instance != nil
               row.push(instance.at("item instanceId").text.ljust(11))
+              # vagrant-aws is broken, so let's write out the id of the EC2 instance ourselves
+              path = ".vagrant/machines/#{@configuration["company"]["name"].downcase}-#{environment}-#{server.gsub("_","-")}/aws"
+              FileUtils.mkpath("#{path}") unless File.exists?("#{path}")
+              File.write("#{path}/id", instance.at("item instanceId").text)
             end
             # size
             if instance != nil


### PR DESCRIPTION
…e EC2 instance ID to enable the .vagrant/machines ID file convention.