### PR TITLE
Windows: Enable AWS Elastic IPs so the public remains the same. Only …

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.92.0
+version: 3.92.1
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -224,6 +224,7 @@ Vagrant.configure("2") do |config|
         "Name" => "#{Catapult::Command.configuration["company"]["name"].downcase}-test-windows"
       }
       provider.user_data = File.read("provisioners/windows/kickstart.txt").gsub(/{{password}}/, Catapult::Command.configuration["environments"]["test"]["servers"]["windows"]["admin_password"])
+      provider.elastic_ip = true
     end
     # windows specific configuration
     config.vm.guest = :windows
@@ -251,6 +252,7 @@ Vagrant.configure("2") do |config|
         "Name" => "#{Catapult::Command.configuration["company"]["name"].downcase}-test-windows-mssql"
       }
       provider.user_data = File.read("provisioners/windows/kickstart.txt").gsub(/{{password}}/, Catapult::Command.configuration["environments"]["test"]["servers"]["windows_mssql"]["admin_password"])
+      provider.elastic_ip = true
     end
     # windows specific configuration
     config.vm.guest = :windows


### PR DESCRIPTION
…use data from running machines (e.g. a terminated AWS instance remains for a few minutes and has no IP).