### PR TITLE
RedHat: Move cloudflare_zones and cloudflare_dns ahead of apache to a…

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.117.5
+version: 3.117.6
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/provisioners/provisioners.yml
+++ b/provisioners/provisioners.yml
@@ -75,7 +75,7 @@ redhat:
       multithreading: false
   servers:
     apache:
-      modules: ["time","system","iptables","newrelic_sysmon","cron","git_clean","software_operations_file","git","git_permissions","software_config","rsync","php","software_tools","apache","apache_vhosts_clean","apache_vhosts","newrelic_apm_php","cloudflare_zones","cloudflare_dns"]
+      modules: ["time","system","iptables","newrelic_sysmon","cron","git_clean","software_operations_file","git","git_permissions","software_config","rsync","php","software_tools","cloudflare_zones","cloudflare_dns","apache","apache_vhosts_clean","apache_vhosts","newrelic_apm_php"]
     bamboo:
       modules: ["time","system","iptables","newrelic_sysmon","cron","bamboo"]
     mysql:


### PR DESCRIPTION
…llow for Let's Encrypt to validate for new virtual hosts. Noting that the DNS may not have yet propagated in time for Let's Encrypt, however, this will give a fighting chance.