### PR TITLE
RedHat: Apache needs reloaded after certificate renewal.

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.138.0
+version: 3.138.1
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/provisioners/redhat/modules/cron_certificates.sh
+++ b/provisioners/redhat/modules/cron_certificates.sh
@@ -6,4 +6,6 @@
 
 /bin/bash /catapult/provisioners/redhat/installers/dehydrated/dehydrated --cron --keep-going
 
+sudo /usr/bin/systemctl reload httpd.service
+
 /bin/echo -e "\n"

--- a/provisioners/windows/provision.py
+++ b/provisioners/windows/provision.py
@@ -2,6 +2,7 @@ import sys
 import winrm
 
 winrmsession = winrm.Session(str(sys.argv[1]),auth=(str(sys.argv[2]),str(sys.argv[3])))
+winrmsession.run_ps("winrm set winrm/config/winrs @{MaxMemoryPerShellMB="512"}")
 winrmsession.run_ps("Set-ExecutionPolicy RemoteSigned")
 result = winrmsession.run_ps( 'powershell -file c:\catapult\provisioners\windows\provision.ps1' + ' "' + str(sys.argv[4]) + '" "' + str(sys.argv[5]) + '" "' + str(sys.argv[6]) + '" "' + str(sys.argv[7]) + '"' )
 


### PR DESCRIPTION
Windows: Increase the MaxMemoryPerShellMB to align with Vagrant’s 512.