### PR TITLE
RedHat: Null kernel IDs are now accepted as DigitalOcean has changed …

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.163.1
+version: 3.163.2
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/catapult/catapult.rb
+++ b/catapult/catapult.rb
@@ -1562,7 +1562,7 @@ module Catapult
           # kernel
           if droplet != nil
             # make sure the droplet has the correct kernel, if not, update it
-            if defined?(droplet["kernel"]["id"]).! || (defined?(droplet["kernel"]["id"]) && "#{droplet["kernel"]["id"]}" != "7516")
+            if (defined?(droplet["kernel"]["id"]) && "#{droplet["kernel"]["id"]}" != "7516")
               puts "   - The Kernel version must be updated to DigitalOcean GrubLoader v0.2, performing now...".color(Colors::YELLOW)
               uri = URI("https://api.digitalocean.com/v2/droplets/#{droplet["id"]}/actions")
               Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|


### PR DESCRIPTION
…the default behavior where null means not set and not managed (at least for CentOS?).