### PR TITLE
RedHat: Allow yum to skip broken dependency packages so that other up…

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.169.2
+version: 3.169.3
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/provisioners/redhat/provision.sh
+++ b/provisioners/redhat/provision.sh
@@ -17,7 +17,7 @@ hostnamectl status
 echo -e "\n\n\n==> INSTALLING MINIMAL DEPENDENCIES"
 
 # update packages
-sudo yum update -y
+sudo yum update -y --skip-broken
 
 # install git
 sudo yum install -y git


### PR DESCRIPTION
…dates are not halted. This happens in the off chance that a dependency is updated ahead of the package and is version locked.