### PR TITLE
RedHat: WP-CLI will upgrade majors (4 to 5) without warning - limit w…

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.182.2
+version: 3.182.3
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/provisioners/redhat/modules/software_operations_file.sh
+++ b/provisioners/redhat/modules/software_operations_file.sh
@@ -313,7 +313,7 @@ if hash composer 2>/dev/null && hash drush 2>/dev/null && hash wp-cli 2>/dev/nul
             if [ "${software_auto_update}" = "true" ]; then
                 cd "/var/www/repositories/apache/${domain}/${webroot}${softwareroot}" && wp-cli --allow-root theme update --all
                 cd "/var/www/repositories/apache/${domain}/${webroot}${softwareroot}" && wp-cli --allow-root plugin update --all
-                cd "/var/www/repositories/apache/${domain}/${webroot}${softwareroot}" && wp-cli --allow-root core update
+                cd "/var/www/repositories/apache/${domain}/${webroot}${softwareroot}" && wp-cli --allow-root core update --version=4.9
                 cd "/var/www/repositories/apache/${domain}/${webroot}${softwareroot}" && wp-cli --allow-root plugin update --all
                 cd "/var/www/repositories/apache/${domain}/${webroot}${softwareroot}" && wp-cli --allow-root theme update --all
             fi


### PR DESCRIPTION
…ordpress4 to just version 4.x.x.