### PR TITLE
Platform: For environments that need it, call Ruby DNS resolver first…

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.194.4
+version: 3.194.5
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/catapult/catapult.rb
+++ b/catapult/catapult.rb
@@ -106,6 +106,7 @@ module Catapult
 
     # check for an internet connection
     require "resolv"
+    require "resolv-replace"
     dns_resolver = Resolv::DNS.new()
     begin
       dns_resolver.getaddress("google.com")


### PR DESCRIPTION
… before passing connection address to TCPSocket via the resolv-replace Net::HTTP patch.