### PR TITLE
RedHat: Adjust the way that localdev syncs the /var/www/repositories …

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
-version: 3.213.8
+version: 3.213.9
 major:
     description: "Catapult uses Semantic Versioning. During a MAJOR increment, incompatable API changes are made which require a manual upgrade path. Please follow these directions:"
     notice: "NEW MAJOR VERSION OF CATAPULT AVAILABLE"

--- a/provisioners/redhat/provision.sh
+++ b/provisioners/redhat/provision.sh
@@ -57,7 +57,11 @@ if ([ $1 = "dev" ]); then
         echo -e "Your Catapult instance is being synced from your host machine."
     fi
     # link the repositories directory for local access from the developer workstation host machine
-    sudo ln -s /catapult/repositories /var/www/ 
+    if [ ! -L /var/www/repositories ]; then
+        sudo rm -rf /var/www/repositories
+        sudo mkdir --parents /var/www
+        sudo ln -s /catapult/repositories /var/www/
+    fi
     force_full_build="true"
 # handle the catapult instance for upstream
 else


### PR DESCRIPTION
…folder to accommodate the latest versions of VirtualBox and Vagrant.